### PR TITLE
Changes to Bintray deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ deploy:
   on:
     tags: true
   key: $BINTRAY_API_KEY
+  skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "clean": "rimraf ./dependencies ./dist",
-    "download": "download https://github.com/Bahmni/openmrs-module-appointments-frontend/releases/download/openmrs-refapp-support-0.0.1/openmrs-module-appointments-frontend.zip -o dependencies",
-    "unzip": "extract-zip ./dependencies/openmrs-module-appointments-frontend.zip",
+    "download": "download https://github.com/Bahmni/openmrs-module-appointments-frontend/releases/download/0.0.1/openmrs-module-appointments-frontend.zip -o dependencies",
+    "unzip": "extract-zip ./dependencies/openmrs-module-appointments-frontend.zip && rm -f ./dependencies/openmrs-module-appointments-frontend.zip",
     "copy": "cp -r ./src/ ./dist/",
-    "zip": "mv dist openmrs-module-appointments-frontend && bestzip openmrs-module-appointments-frontend.zip openmrs-module-appointments-frontend",
+    "zip": "mv dist appointments && bestzip appointments-${npm_package_version}.zip appointments",
     "build": "npm run clean && npm run download && npm run unzip && npm run copy && npm run zip"
   },
   "dependencies": {},


### PR DESCRIPTION
As part of this PR following things are done:
- Add `skip_cleanup:true` because we are uploading a file that gets generated.
- Update the appointments-frontend version to released version from the master branch.
- Cleanup downloaded zip so it doesn't get uploaded.
- Include `npm package version` as part of the artifact name.